### PR TITLE
Prepare for v1.0.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: release-action
+
+on:
+  push:
+    tags:
+      - "[0-9].[0-9]+.[0-9]+"
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set the version
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION }}
+          release_name: Version ${{ env.VERSION }}
+          draft: false
+          prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.0
+
+* Initial release with ability to make an authenticated call to the
+  deployment-associator endpoint on Hub while handling the response accordingly.


### PR DESCRIPTION
Add GitHub Action to automate creating a GitHub Release on tagging and also add a `CHANGELOG`.